### PR TITLE
Register FluentValidation validators

### DIFF
--- a/BudgetSystem.Api/Program.cs
+++ b/BudgetSystem.Api/Program.cs
@@ -1,6 +1,8 @@
 using BudgetSystem.Api.Endpoints;                 // endpoint modules (Map*Endpoints)
 using BudgetSystem.Api.Middleware;               // IdempotencyMiddleware
 using BudgetSystem.Infrastructure.Persistence;   // AppDbContext
+using BudgetSystem.Application.Validation;       // validators
+using FluentValidation;                          // FluentValidation services
 using Microsoft.AspNetCore.Diagnostics;          // exception handler feature
 using Microsoft.EntityFrameworkCore;
 
@@ -16,6 +18,10 @@ builder.Services.AddProblemDetails();
 // EF Core
 var conn = builder.Configuration.GetConnectionString("DefaultConnection");
 builder.Services.AddDbContext<AppDbContext>(o => o.UseSqlServer(conn));
+
+// FluentValidation
+builder.Services.AddValidatorsFromAssemblyContaining<AccountCreateValidator>();
+builder.Services.AddFluentValidationAutoValidation();
 
 var app = builder.Build();
 


### PR DESCRIPTION
## Summary
- add FluentValidation usings and service registrations

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a57093bbf08329aac71c22a4ea5a78