### PR TITLE
Add account management endpoints

### DIFF
--- a/BudgetSystem.Api/Endpoints/AccountEndpoints.cs
+++ b/BudgetSystem.Api/Endpoints/AccountEndpoints.cs
@@ -1,5 +1,8 @@
 using BudgetSystem.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
+using BudgetSystem.Application.DTOs;
+using BudgetSystem.Application.Mappers;
+using FluentValidation;
 
 namespace BudgetSystem.Api.Endpoints;
 
@@ -21,6 +24,64 @@ public static class AccountEndpoints
                 .Select(a => new { a.Id, a.Name, a.StartingBalance, a.Currency, a.CreatedUtc, a.UpdatedUtc })
                 .FirstOrDefaultAsync();
             return item is null ? Results.NotFound() : Results.Ok(item);
+        });
+
+        g.MapPost("/", async (
+            AccountCreateDto dto,
+            IValidator<AccountCreateDto> validator,
+            AppDbContext db) =>
+        {
+            var validation = await validator.ValidateAsync(dto);
+            if (!validation.IsValid)
+                return Results.ValidationProblem(validation.ToDictionary());
+
+            var entity = dto.ToEntity();
+            db.Accounts.Add(entity);
+            await db.SaveChangesAsync();
+
+            var result = new
+            {
+                entity.Id,
+                entity.Name,
+                entity.StartingBalance,
+                entity.Currency,
+                entity.CreatedUtc,
+                entity.UpdatedUtc
+            };
+
+            return Results.Created($"/api/v1/accounts/{entity.Id}", result);
+        });
+
+        g.MapPut("/{id:int}", async (
+            int id,
+            AccountUpdateDto dto,
+            IValidator<AccountUpdateDto> validator,
+            AppDbContext db) =>
+        {
+            var validation = await validator.ValidateAsync(dto);
+            if (!validation.IsValid)
+                return Results.ValidationProblem(validation.ToDictionary());
+
+            var entity = await db.Accounts.FindAsync(id);
+            if (entity is null)
+                return Results.NotFound();
+
+            dto.MapTo(entity);
+            await db.SaveChangesAsync();
+
+            return Results.NoContent();
+        });
+
+        g.MapDelete("/{id:int}", async (int id, AppDbContext db) =>
+        {
+            var entity = await db.Accounts.FindAsync(id);
+            if (entity is null)
+                return Results.NotFound();
+
+            db.Accounts.Remove(entity);
+            await db.SaveChangesAsync();
+
+            return Results.NoContent();
         });
 
         return app;


### PR DESCRIPTION
## Summary
- add POST, PUT, and DELETE handlers for account API
- validate create and update requests using FluentValidation
- map DTOs to entities and persist changes via AppDbContext

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a57094ca0883298fdd8cd9a36c9dc8