### PR TITLE
Add basic Razor Pages UI and integrate FluentValidation

### DIFF
--- a/BudgetSystem.Api/Pages/Error.cshtml
+++ b/BudgetSystem.Api/Pages/Error.cshtml
@@ -1,0 +1,26 @@
+@page
+@model ErrorModel
+@{
+    ViewData["Title"] = "Error";
+}
+
+<h1 class="text-danger">Error.</h1>
+<h2 class="text-danger">An error occurred while processing your request.</h2>
+
+@if (Model.ShowRequestId)
+{
+    <p>
+        <strong>Request ID:</strong> <code>@Model.RequestId</code>
+    </p>
+}
+
+<h3>Development Mode</h3>
+<p>
+    Swapping to the <strong>Development</strong> environment displays detailed information about the error that occurred.
+</p>
+<p>
+    <strong>The Development environment shouldn't be enabled for deployed applications.</strong>
+    It can result in displaying sensitive information from exceptions to end users.
+    For local debugging, enable the <strong>Development</strong> environment by setting the <strong>ASPNETCORE_ENVIRONMENT</strong> environment variable to <strong>Development</strong>
+    and restarting the app.
+</p>

--- a/BudgetSystem.Api/Pages/Error.cshtml.cs
+++ b/BudgetSystem.Api/Pages/Error.cshtml.cs
@@ -1,0 +1,26 @@
+using System.Diagnostics;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace BudgetSystem.Api.Pages;
+
+[ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
+[IgnoreAntiforgeryToken]
+public class ErrorModel : PageModel
+{
+    public string? RequestId { get; set; }
+
+    public bool ShowRequestId => !string.IsNullOrEmpty(RequestId);
+
+    private readonly ILogger<ErrorModel> _logger;
+
+    public ErrorModel(ILogger<ErrorModel> logger)
+    {
+        _logger = logger;
+    }
+
+    public void OnGet()
+    {
+        RequestId = Activity.Current?.Id ?? HttpContext.TraceIdentifier;
+    }
+}

--- a/BudgetSystem.Api/Pages/Index.cshtml
+++ b/BudgetSystem.Api/Pages/Index.cshtml
@@ -1,0 +1,21 @@
+@page
+@model IndexModel
+@{
+    ViewData["Title"] = "Accounts";
+}
+
+<h1>Accounts</h1>
+
+@if (Model.Accounts.Count == 0)
+{
+    <p>No accounts available.</p>
+}
+else
+{
+    <ul>
+    @foreach (var acc in Model.Accounts)
+    {
+        <li>@acc.Name (@acc.Currency) - @acc.StartingBalance</li>
+    }
+    </ul>
+}

--- a/BudgetSystem.Api/Pages/Index.cshtml.cs
+++ b/BudgetSystem.Api/Pages/Index.cshtml.cs
@@ -1,0 +1,20 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace BudgetSystem.Api.Pages;
+
+public class IndexModel : PageModel
+{
+    private readonly ApiClient _api;
+
+    public List<ApiClient.AccountVm> Accounts { get; private set; } = new();
+
+    public IndexModel(ApiClient api)
+    {
+        _api = api;
+    }
+
+    public async Task OnGetAsync()
+    {
+        Accounts = await _api.GetAccountsAsync();
+    }
+}

--- a/BudgetSystem.Api/Pages/Privacy.cshtml
+++ b/BudgetSystem.Api/Pages/Privacy.cshtml
@@ -1,0 +1,9 @@
+@page
+@model PrivacyModel
+@{
+    ViewData["Title"] = "Privacy Policy";
+}
+
+<h1>@ViewData["Title"]</h1>
+
+<p>Use this page to detail your site's privacy policy.</p>

--- a/BudgetSystem.Api/Pages/Privacy.cshtml.cs
+++ b/BudgetSystem.Api/Pages/Privacy.cshtml.cs
@@ -1,0 +1,17 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace BudgetSystem.Api.Pages;
+
+public class PrivacyModel : PageModel
+{
+    private readonly ILogger<PrivacyModel> _logger;
+
+    public PrivacyModel(ILogger<PrivacyModel> logger)
+    {
+        _logger = logger;
+    }
+
+    public void OnGet()
+    {
+    }
+}

--- a/BudgetSystem.Api/Pages/Shared/_Layout.cshtml
+++ b/BudgetSystem.Api/Pages/Shared/_Layout.cshtml
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>@ViewData["Title"] - BudgetSystem.Api</title>
+</head>
+<body>
+    <header>
+        <nav>
+            <a asp-page="/Index">Home</a> |
+            <a asp-page="/Privacy">Privacy</a>
+        </nav>
+    </header>
+    <div class="container">
+        <main role="main" class="pb-3">
+            @RenderBody()
+        </main>
+    </div>
+    <footer>
+        &copy; @DateTime.Now.Year - BudgetSystem.Api
+    </footer>
+    @RenderSection("Scripts", required: false)
+</body>
+</html>

--- a/BudgetSystem.Api/Pages/_ViewImports.cshtml
+++ b/BudgetSystem.Api/Pages/_ViewImports.cshtml
@@ -1,0 +1,3 @@
+@using BudgetSystem.Api
+@namespace BudgetSystem.Api.Pages
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/BudgetSystem.Api/Pages/_ViewStart.cshtml
+++ b/BudgetSystem.Api/Pages/_ViewStart.cshtml
@@ -1,0 +1,3 @@
+@{
+    Layout = "_Layout";
+}

--- a/BudgetSystem.Api/Program.cs
+++ b/BudgetSystem.Api/Program.cs
@@ -3,10 +3,9 @@ using BudgetSystem.Api.Middleware;               // IdempotencyMiddleware
 using BudgetSystem.Infrastructure.Persistence;   // AppDbContext
 using BudgetSystem.Application.Validation;       // validators
 using FluentValidation;                          // FluentValidation services
+using FluentValidation.AspNetCore;               // automatic validation integration
 using Microsoft.AspNetCore.Diagnostics;          // exception handler feature
 using Microsoft.EntityFrameworkCore;
-using FluentValidation;
-using BudgetSystem.Application.Validation;
 
 var builder = WebApplication.CreateBuilder(args);
 


### PR DESCRIPTION
## Summary
- hook up `AddFluentValidationAutoValidation` by importing `FluentValidation.AspNetCore`
- scaffold Razor Pages with layout, index listing accounts from the API, plus privacy and error pages

## Testing
- `dotnet build` *(fails: dotnet command not found)*
- `wget https://packages.microsoft.com/config/ubuntu/24.04/packages-microsoft-prod.deb` *(fails: Proxy tunneling failed: ForbiddenUnable to establish SSL connection)*

------
https://chatgpt.com/codex/tasks/task_e_68a575dfe6708329978db5f833a23b3b