### PR TITLE
Add ApiClient and account creation page

### DIFF
--- a/BudgetSystem.Web/ApiClient.cs
+++ b/BudgetSystem.Web/ApiClient.cs
@@ -1,0 +1,30 @@
+using System.Net.Http.Json;
+
+namespace BudgetSystem.Web;
+
+/// <summary>
+/// Thin wrapper over <see cref="HttpClient"/> used by the razor pages to talk to the backend API.
+/// </summary>
+public class ApiClient
+{
+    private readonly HttpClient _http;
+
+    public ApiClient(HttpClient http) => _http = http;
+
+    // Accounts
+    public async Task<List<AccountVm>> GetAccountsAsync()
+        => await _http.GetFromJsonAsync<List<AccountVm>>("/api/v1/accounts") ?? new();
+
+    public async Task<int> CreateAccountAsync(AccountCreateDto dto)
+    {
+        var resp = await _http.PostAsJsonAsync("/api/v1/accounts", dto);
+        if (!resp.IsSuccessStatusCode)
+            throw new HttpRequestException($"Create failed: {(int)resp.StatusCode} {resp.ReasonPhrase}");
+        var payload = await resp.Content.ReadFromJsonAsync<CreatedId>();
+        return payload?.Id ?? 0;
+    }
+
+    private record CreatedId(int Id);
+    public record AccountVm(int Id, string Name, decimal StartingBalance, string Currency, DateTime CreatedUtc, DateTime? UpdatedUtc);
+    public record AccountCreateDto(string Name, decimal StartingBalance, string Currency = "PHP");
+}

--- a/BudgetSystem.Web/Pages/Accounts/Create.cshtml
+++ b/BudgetSystem.Web/Pages/Accounts/Create.cshtml
@@ -1,0 +1,30 @@
+@page
+@model BudgetSystem.Web.Pages.Accounts.CreateModel
+@{
+    ViewData["Title"] = "Create Account";
+}
+
+<h1>Create Account</h1>
+
+<form method="post">
+    <div class="mb-3">
+        <label asp-for="Form.Name" class="form-label"></label>
+        <input asp-for="Form.Name" class="form-control" />
+        <span asp-validation-for="Form.Name" class="text-danger"></span>
+    </div>
+    <div class="mb-3">
+        <label asp-for="Form.StartingBalance" class="form-label"></label>
+        <input asp-for="Form.StartingBalance" class="form-control" />
+        <span asp-validation-for="Form.StartingBalance" class="text-danger"></span>
+    </div>
+    <div class="mb-3">
+        <label asp-for="Form.Currency" class="form-label"></label>
+        <input asp-for="Form.Currency" class="form-control" />
+        <span asp-validation-for="Form.Currency" class="text-danger"></span>
+    </div>
+    <button type="submit" class="btn btn-primary">Create</button>
+</form>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/BudgetSystem.Web/Pages/Accounts/Create.cshtml.cs
+++ b/BudgetSystem.Web/Pages/Accounts/Create.cshtml.cs
@@ -1,0 +1,32 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace BudgetSystem.Web.Pages.Accounts;
+
+public class CreateModel : PageModel
+{
+    private readonly ApiClient _api;
+
+    [BindProperty]
+    public ApiClient.AccountCreateDto Form { get; set; } = new("", 0m);
+
+    public CreateModel(ApiClient api)
+    {
+        _api = api;
+    }
+
+    public void OnGet()
+    {
+    }
+
+    public async Task<IActionResult> OnPostAsync()
+    {
+        if (!ModelState.IsValid)
+        {
+            return Page();
+        }
+
+        await _api.CreateAccountAsync(Form);
+        return RedirectToPage("/Index");
+    }
+}

--- a/BudgetSystem.Web/Program.cs
+++ b/BudgetSystem.Web/Program.cs
@@ -3,6 +3,14 @@ var builder = WebApplication.CreateBuilder(args);
 // Add services to the container.
 builder.Services.AddRazorPages();
 
+// Typed HttpClient used by the Razor pages to talk to the API
+builder.Services.AddHttpClient<ApiClient>(client =>
+{
+    var baseUrl = builder.Configuration["Api:BaseUrl"]
+                  ?? throw new InvalidOperationException("Api:BaseUrl missing");
+    client.BaseAddress = new Uri(baseUrl);
+});
+
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.


### PR DESCRIPTION
## Summary
- add ApiClient wrapper for calling backend API
- register typed HttpClient for ApiClient and create account Razor page

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5777188188329b3b0f912835a53c5