### PR TITLE
fix: use http API base URL

### DIFF
--- a/BudgetSystem.Web/appsettings.json
+++ b/BudgetSystem.Web/appsettings.json
@@ -7,6 +7,6 @@
   },
   "AllowedHosts": "*",
   "Api": {
-    "BaseUrl": "https://localhost:5090" 
+    "BaseUrl": "http://localhost:5090"
   }
 }


### PR DESCRIPTION
## Summary
- use HTTP for API base URL to match running service

## Testing
- `dotnet build budgetTracker/BudgetSystem.sln` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a57f6b7c408329994f41cabf1c5e93