### PR TITLE
Add budget pages and API client support

### DIFF
--- a/BudgetSystem.Client/ApiClient.cs
+++ b/BudgetSystem.Client/ApiClient.cs
@@ -24,7 +24,27 @@ public class ApiClient
         return payload?.Id ?? 0;
     }
 
+    // Categories
+    public async Task<List<CategoryVm>> GetCategoriesAsync()
+        => await _http.GetFromJsonAsync<List<CategoryVm>>("/api/v1/categories") ?? new();
+
+    // Budgets
+    public async Task<List<BudgetVm>> GetBudgetsAsync()
+        => await _http.GetFromJsonAsync<List<BudgetVm>>("/api/v1/budgets") ?? new();
+
+    public async Task<int> CreateBudgetAsync(BudgetCreateDto dto)
+    {
+        var resp = await _http.PostAsJsonAsync("/api/v1/budgets", dto);
+        if (!resp.IsSuccessStatusCode)
+            throw new HttpRequestException($"Create failed: {(int)resp.StatusCode} {resp.ReasonPhrase}");
+        var payload = await resp.Content.ReadFromJsonAsync<CreatedId>();
+        return payload?.Id ?? 0;
+    }
+
     private record CreatedId(int Id);
     public record AccountVm(int Id, string Name, decimal StartingBalance, string Currency, DateTime CreatedUtc, DateTime? UpdatedUtc);
     public record AccountCreateDto(string Name, decimal StartingBalance, string Currency = "PHP");
+    public record CategoryVm(int Id, string Name, int Type, int? AccountId, bool IsArchived, DateTime CreatedUtc, DateTime? UpdatedUtc);
+    public record BudgetVm(int Id, int Year, int Month, decimal LimitAmount, int AccountId, int? CategoryId, DateTime CreatedUtc, DateTime? UpdatedUtc);
+    public record BudgetCreateDto(int Year, int Month, decimal LimitAmount, int AccountId, int? CategoryId);
 }

--- a/BudgetSystem.Web/Pages/Budgets/Create.cshtml
+++ b/BudgetSystem.Web/Pages/Budgets/Create.cshtml
@@ -1,0 +1,43 @@
+@page
+@model BudgetSystem.Web.Pages.Budgets.CreateModel
+@{
+    ViewData["Title"] = "Create Budget";
+}
+
+<h1>Create Budget</h1>
+
+<form method="post">
+    <div class="mb-3">
+        <label asp-for="Form.Year" class="form-label"></label>
+        <input asp-for="Form.Year" class="form-control" />
+        <span asp-validation-for="Form.Year" class="text-danger"></span>
+    </div>
+    <div class="mb-3">
+        <label asp-for="Form.Month" class="form-label"></label>
+        <input asp-for="Form.Month" class="form-control" />
+        <span asp-validation-for="Form.Month" class="text-danger"></span>
+    </div>
+    <div class="mb-3">
+        <label asp-for="Form.LimitAmount" class="form-label"></label>
+        <input asp-for="Form.LimitAmount" class="form-control" />
+        <span asp-validation-for="Form.LimitAmount" class="text-danger"></span>
+    </div>
+    <div class="mb-3">
+        <label asp-for="Form.AccountId" class="form-label"></label>
+        <select asp-for="Form.AccountId" class="form-select" asp-items="Model.Accounts"></select>
+        <span asp-validation-for="Form.AccountId" class="text-danger"></span>
+    </div>
+    <div class="mb-3">
+        <label asp-for="Form.CategoryId" class="form-label"></label>
+        <select asp-for="Form.CategoryId" class="form-select" asp-items="Model.Categories">
+            <option value="">-- None --</option>
+        </select>
+        <span asp-validation-for="Form.CategoryId" class="text-danger"></span>
+    </div>
+    <button type="submit" class="btn btn-primary">Create</button>
+</form>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}
+

--- a/BudgetSystem.Web/Pages/Budgets/Create.cshtml.cs
+++ b/BudgetSystem.Web/Pages/Budgets/Create.cshtml.cs
@@ -1,0 +1,49 @@
+using BudgetSystem.Client;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Mvc.Rendering;
+
+namespace BudgetSystem.Web.Pages.Budgets;
+
+public class CreateModel : PageModel
+{
+    private readonly ApiClient _api;
+
+    [BindProperty]
+    public ApiClient.BudgetCreateDto Form { get; set; } = new(0, 0, 0m, 0, null);
+
+    public SelectList Accounts { get; set; } = default!;
+    public SelectList Categories { get; set; } = default!;
+
+    public CreateModel(ApiClient api)
+    {
+        _api = api;
+    }
+
+    public async Task OnGetAsync()
+    {
+        await LoadLookups();
+    }
+
+    public async Task<IActionResult> OnPostAsync()
+    {
+        if (!ModelState.IsValid)
+        {
+            await LoadLookups();
+            return Page();
+        }
+
+        await _api.CreateBudgetAsync(Form);
+        return RedirectToPage("Index");
+    }
+
+    private async Task LoadLookups()
+    {
+        var accounts = await _api.GetAccountsAsync();
+        Accounts = new SelectList(accounts, nameof(ApiClient.AccountVm.Id), nameof(ApiClient.AccountVm.Name));
+
+        var categories = await _api.GetCategoriesAsync();
+        Categories = new SelectList(categories, nameof(ApiClient.CategoryVm.Id), nameof(ApiClient.CategoryVm.Name));
+    }
+}
+

--- a/BudgetSystem.Web/Pages/Budgets/Index.cshtml
+++ b/BudgetSystem.Web/Pages/Budgets/Index.cshtml
@@ -1,0 +1,34 @@
+@page
+@model BudgetSystem.Web.Pages.Budgets.IndexModel
+@{
+    ViewData["Title"] = "Budgets";
+}
+
+<h1 class="mt-3">Budgets</h1>
+
+<p>
+    <a class="btn btn-primary" asp-page="Create">Create Budget</a>
+    </p>
+
+<table class="table table-striped">
+    <thead>
+        <tr>
+            <th>Id</th><th>Year</th><th>Month</th><th>Limit</th><th>Account</th><th>Category</th><th>Created</th>
+        </tr>
+    </thead>
+    <tbody>
+    @foreach (var b in Model.Budgets)
+    {
+        <tr>
+            <td>@b.Id</td>
+            <td>@b.Year</td>
+            <td>@b.Month</td>
+            <td>@b.LimitAmount</td>
+            <td>@b.AccountId</td>
+            <td>@b.CategoryId</td>
+            <td>@b.CreatedUtc.ToLocalTime()</td>
+        </tr>
+    }
+    </tbody>
+</table>
+

--- a/BudgetSystem.Web/Pages/Budgets/Index.cshtml.cs
+++ b/BudgetSystem.Web/Pages/Budgets/Index.cshtml.cs
@@ -1,0 +1,15 @@
+using BudgetSystem.Client;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace BudgetSystem.Web.Pages.Budgets;
+
+public class IndexModel(ApiClient api) : PageModel
+{
+    public List<ApiClient.BudgetVm> Budgets { get; private set; } = new();
+
+    public async Task OnGet()
+    {
+        Budgets = await api.GetBudgetsAsync();
+    }
+}
+


### PR DESCRIPTION
## Summary
- extend ApiClient with budget and category helpers
- add Budgets index and create Razor pages

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5824bba8c8329a4e4d92c5a6bc76b