### PR TITLE
Add transaction API support and pages

### DIFF
--- a/BudgetSystem.Client/ApiClient.cs
+++ b/BudgetSystem.Client/ApiClient.cs
@@ -24,7 +24,28 @@ public class ApiClient
         return payload?.Id ?? 0;
     }
 
+    // Categories
+    public async Task<List<CategoryVm>> GetCategoriesAsync()
+        => await _http.GetFromJsonAsync<List<CategoryVm>>("/api/v1/categories") ?? new();
+
+    // Transactions
+    public async Task<List<TransactionVm>> GetTransactionsAsync()
+        => await _http.GetFromJsonAsync<List<TransactionVm>>("/api/v1/transactions") ?? new();
+
+    public async Task<int> CreateTransactionAsync(TransactionCreateDto dto)
+    {
+        var resp = await _http.PostAsJsonAsync("/api/v1/transactions", dto);
+        if (!resp.IsSuccessStatusCode)
+            throw new HttpRequestException($"Create failed: {(int)resp.StatusCode} {resp.ReasonPhrase}");
+        var payload = await resp.Content.ReadFromJsonAsync<CreatedId>();
+        return payload?.Id ?? 0;
+    }
+
     private record CreatedId(int Id);
     public record AccountVm(int Id, string Name, decimal StartingBalance, string Currency, DateTime CreatedUtc, DateTime? UpdatedUtc);
     public record AccountCreateDto(string Name, decimal StartingBalance, string Currency = "PHP");
+    public record CategoryVm(int Id, string Name, TransactionType Type, int? AccountId, bool IsArchived, DateTime CreatedUtc, DateTime? UpdatedUtc);
+    public enum TransactionType { Income, Expense, Transfer }
+    public record TransactionVm(int Id, DateTime Date, decimal Amount, TransactionType Type, string? Notes, int AccountId, int? CategoryId, int? FromAccountId, int? ToAccountId, DateTime CreatedUtc, DateTime? UpdatedUtc);
+    public record TransactionCreateDto(DateTime Date, decimal Amount, TransactionType Type, int AccountId, int? CategoryId = null, int? FromAccountId = null, int? ToAccountId = null, string? Notes = null);
 }

--- a/BudgetSystem.Web/Pages/Transactions/Create.cshtml
+++ b/BudgetSystem.Web/Pages/Transactions/Create.cshtml
@@ -1,0 +1,57 @@
+@page
+@using BudgetSystem.Client
+@model BudgetSystem.Web.Pages.Transactions.CreateModel
+@{
+    ViewData["Title"] = "Create Transaction";
+}
+
+<h1>Create Transaction</h1>
+
+<form method="post">
+    <div class="mb-3">
+        <label asp-for="Form.Date" class="form-label"></label>
+        <input asp-for="Form.Date" class="form-control" />
+        <span asp-validation-for="Form.Date" class="text-danger"></span>
+    </div>
+    <div class="mb-3">
+        <label asp-for="Form.Amount" class="form-label"></label>
+        <input asp-for="Form.Amount" class="form-control" />
+        <span asp-validation-for="Form.Amount" class="text-danger"></span>
+    </div>
+    <div class="mb-3">
+        <label asp-for="Form.Type" class="form-label"></label>
+        <select asp-for="Form.Type" class="form-select" asp-items="Html.GetEnumSelectList<ApiClient.TransactionType>()"></select>
+        <span asp-validation-for="Form.Type" class="text-danger"></span>
+    </div>
+    <div class="mb-3">
+        <label asp-for="Form.AccountId" class="form-label"></label>
+        <select asp-for="Form.AccountId" class="form-select" asp-items="Model.AccountOptions"></select>
+        <span asp-validation-for="Form.AccountId" class="text-danger"></span>
+    </div>
+    <div class="mb-3">
+        <label asp-for="Form.CategoryId" class="form-label"></label>
+        <select asp-for="Form.CategoryId" class="form-select" asp-items="Model.CategoryOptions">
+            <option value="">-- None --</option>
+        </select>
+        <span asp-validation-for="Form.CategoryId" class="text-danger"></span>
+    </div>
+    <div class="mb-3">
+        <label asp-for="Form.FromAccountId" class="form-label"></label>
+        <select asp-for="Form.FromAccountId" class="form-select" asp-items="Model.AccountOptions">
+            <option value="">-- None --</option>
+        </select>
+        <span asp-validation-for="Form.FromAccountId" class="text-danger"></span>
+    </div>
+    <div class="mb-3">
+        <label asp-for="Form.ToAccountId" class="form-label"></label>
+        <select asp-for="Form.ToAccountId" class="form-select" asp-items="Model.AccountOptions">
+            <option value="">-- None --</option>
+        </select>
+        <span asp-validation-for="Form.ToAccountId" class="text-danger"></span>
+    </div>
+    <button type="submit" class="btn btn-primary">Create</button>
+</form>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/BudgetSystem.Web/Pages/Transactions/Create.cshtml.cs
+++ b/BudgetSystem.Web/Pages/Transactions/Create.cshtml.cs
@@ -1,0 +1,46 @@
+using BudgetSystem.Client;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace BudgetSystem.Web.Pages.Transactions;
+
+public class CreateModel : PageModel
+{
+    private readonly ApiClient _api;
+
+    public List<ApiClient.AccountVm> Accounts { get; private set; } = new();
+    public List<ApiClient.CategoryVm> Categories { get; private set; } = new();
+
+    public SelectList AccountOptions => new(Accounts, "Id", "Name");
+    public SelectList CategoryOptions => new(Categories, "Id", "Name");
+
+    [BindProperty]
+    public ApiClient.TransactionCreateDto Form { get; set; } =
+        new(DateTime.UtcNow, 0m, ApiClient.TransactionType.Expense, 0);
+
+    public CreateModel(ApiClient api)
+    {
+        _api = api;
+    }
+
+    public async Task OnGet()
+    {
+        Accounts = await _api.GetAccountsAsync();
+        Categories = await _api.GetCategoriesAsync();
+    }
+
+    public async Task<IActionResult> OnPostAsync()
+    {
+        Accounts = await _api.GetAccountsAsync();
+        Categories = await _api.GetCategoriesAsync();
+
+        if (!ModelState.IsValid)
+        {
+            return Page();
+        }
+
+        await _api.CreateTransactionAsync(Form);
+        return RedirectToPage("Index");
+    }
+}

--- a/BudgetSystem.Web/Pages/Transactions/Index.cshtml
+++ b/BudgetSystem.Web/Pages/Transactions/Index.cshtml
@@ -1,0 +1,32 @@
+@page
+@model BudgetSystem.Web.Pages.Transactions.IndexModel
+@{
+    ViewData["Title"] = "Transactions";
+}
+<h1 class="mt-3">Transactions</h1>
+
+<p>
+    <a class="btn btn-primary" asp-page="Create">Create Transaction</a>
+</p>
+
+<table class="table table-striped">
+    <thead>
+        <tr>
+            <th>Id</th>
+            <th>Date</th>
+            <th>Amount</th>
+            <th>Type</th>
+        </tr>
+    </thead>
+    <tbody>
+    @foreach (var t in Model.Transactions)
+    {
+        <tr>
+            <td>@t.Id</td>
+            <td>@t.Date.ToLocalTime()</td>
+            <td>@t.Amount</td>
+            <td>@t.Type</td>
+        </tr>
+    }
+    </tbody>
+</table>

--- a/BudgetSystem.Web/Pages/Transactions/Index.cshtml.cs
+++ b/BudgetSystem.Web/Pages/Transactions/Index.cshtml.cs
@@ -1,0 +1,14 @@
+using BudgetSystem.Client;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace BudgetSystem.Web.Pages.Transactions;
+
+public class IndexModel(ApiClient api) : PageModel
+{
+    public List<ApiClient.TransactionVm> Transactions { get; private set; } = new();
+
+    public async Task OnGet()
+    {
+        Transactions = await api.GetTransactionsAsync();
+    }
+}


### PR DESCRIPTION
## Summary
- extend API client with categories and transactions support
- add transaction listing page with create link
- add transaction creation page with dropdowns and validation

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5824aaf808329aec8e8c648b24acc