### PR TITLE
Add category pages and API client support

### DIFF
--- a/BudgetSystem.Client/ApiClient.cs
+++ b/BudgetSystem.Client/ApiClient.cs
@@ -24,7 +24,29 @@ public class ApiClient
         return payload?.Id ?? 0;
     }
 
+    // Categories
+    public async Task<List<CategoryVm>> GetCategoriesAsync()
+        => await _http.GetFromJsonAsync<List<CategoryVm>>("/api/v1/categories") ?? new();
+
+    public async Task<int> CreateCategoryAsync(CategoryCreateDto dto)
+    {
+        var resp = await _http.PostAsJsonAsync("/api/v1/categories", dto);
+        if (!resp.IsSuccessStatusCode)
+            throw new HttpRequestException($"Create failed: {(int)resp.StatusCode} {resp.ReasonPhrase}");
+        var payload = await resp.Content.ReadFromJsonAsync<CreatedId>();
+        return payload?.Id ?? 0;
+    }
+
     private record CreatedId(int Id);
     public record AccountVm(int Id, string Name, decimal StartingBalance, string Currency, DateTime CreatedUtc, DateTime? UpdatedUtc);
     public record AccountCreateDto(string Name, decimal StartingBalance, string Currency = "PHP");
+
+    public record CategoryVm(int Id, string Name, TransactionType Type, int? AccountId, bool IsArchived, DateTime CreatedUtc, DateTime? UpdatedUtc);
+    public record CategoryCreateDto(string Name, TransactionType Type, int? AccountId);
+    public enum TransactionType
+    {
+        Income = 1,
+        Expense = 2,
+        Transfer = 3
+    }
 }

--- a/BudgetSystem.Web/Pages/Categories/Create.cshtml
+++ b/BudgetSystem.Web/Pages/Categories/Create.cshtml
@@ -1,0 +1,30 @@
+@page
+@model BudgetSystem.Web.Pages.Categories.CreateModel
+@{
+    ViewData["Title"] = "Create Category";
+}
+
+<h1>Create Category</h1>
+
+<form method="post">
+    <div class="mb-3">
+        <label asp-for="Form.Name" class="form-label"></label>
+        <input asp-for="Form.Name" class="form-control" />
+        <span asp-validation-for="Form.Name" class="text-danger"></span>
+    </div>
+    <div class="mb-3">
+        <label asp-for="Form.Type" class="form-label"></label>
+        <select asp-for="Form.Type" class="form-select" asp-items="Html.GetEnumSelectList<ApiClient.TransactionType>()"></select>
+        <span asp-validation-for="Form.Type" class="text-danger"></span>
+    </div>
+    <div class="mb-3">
+        <label asp-for="Form.AccountId" class="form-label"></label>
+        <input asp-for="Form.AccountId" class="form-control" />
+        <span asp-validation-for="Form.AccountId" class="text-danger"></span>
+    </div>
+    <button type="submit" class="btn btn-primary">Create</button>
+</form>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/BudgetSystem.Web/Pages/Categories/Create.cshtml.cs
+++ b/BudgetSystem.Web/Pages/Categories/Create.cshtml.cs
@@ -1,0 +1,33 @@
+using BudgetSystem.Client;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace BudgetSystem.Web.Pages.Categories;
+
+public class CreateModel : PageModel
+{
+    private readonly ApiClient _api;
+
+    [BindProperty]
+    public ApiClient.CategoryCreateDto Form { get; set; } = new("", ApiClient.TransactionType.Expense, null);
+
+    public CreateModel(ApiClient api)
+    {
+        _api = api;
+    }
+
+    public void OnGet()
+    {
+    }
+
+    public async Task<IActionResult> OnPostAsync()
+    {
+        if (!ModelState.IsValid)
+        {
+            return Page();
+        }
+
+        await _api.CreateCategoryAsync(Form);
+        return RedirectToPage("Index");
+    }
+}

--- a/BudgetSystem.Web/Pages/Categories/Index.cshtml
+++ b/BudgetSystem.Web/Pages/Categories/Index.cshtml
@@ -1,0 +1,30 @@
+@page
+@model BudgetSystem.Web.Pages.Categories.IndexModel
+@{
+    ViewData["Title"] = "Categories";
+}
+<h1 class="mt-3">Categories</h1>
+
+<p>
+    <a class="btn btn-primary" asp-page="Create">Create Category</a>
+</p>
+
+<table class="table table-striped">
+    <thead>
+        <tr>
+            <th>Id</th><th>Name</th><th>Type</th><th>Account</th><th>Created</th>
+        </tr>
+    </thead>
+    <tbody>
+    @foreach (var c in Model.Categories)
+    {
+        <tr>
+            <td>@c.Id</td>
+            <td>@c.Name</td>
+            <td>@c.Type</td>
+            <td>@c.AccountId</td>
+            <td>@c.CreatedUtc.ToLocalTime()</td>
+        </tr>
+    }
+    </tbody>
+</table>

--- a/BudgetSystem.Web/Pages/Categories/Index.cshtml.cs
+++ b/BudgetSystem.Web/Pages/Categories/Index.cshtml.cs
@@ -1,0 +1,14 @@
+using BudgetSystem.Client;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace BudgetSystem.Web.Pages.Categories;
+
+public class IndexModel(ApiClient api) : PageModel
+{
+    public List<ApiClient.CategoryVm> Categories { get; private set; } = new();
+
+    public async Task OnGet()
+    {
+        Categories = await api.GetCategoriesAsync();
+    }
+}


### PR DESCRIPTION
## Summary
- extend ApiClient with Category models and CRUD methods
- add Razor Pages to list categories and create new ones

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a5824900f4832995845a0474a9b58f