### PR TITLE
Add missing ApiClient import for category creation page

### DIFF
--- a/BudgetSystem.Web/Pages/Categories/Create.cshtml
+++ b/BudgetSystem.Web/Pages/Categories/Create.cshtml
@@ -1,4 +1,5 @@
 @page
+@using BudgetSystem.Client
 @model BudgetSystem.Web.Pages.Categories.CreateModel
 @{
     ViewData["Title"] = "Create Category";


### PR DESCRIPTION
## Summary
- fix compilation error in category creation view by adding ApiClient namespace

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a589cb1b9083298517350464a3c61a