### PR TITLE
Use view model for account creation

### DIFF
--- a/BudgetSystem.Web/Pages/Accounts/Create.cshtml.cs
+++ b/BudgetSystem.Web/Pages/Accounts/Create.cshtml.cs
@@ -9,7 +9,7 @@ public class CreateModel : PageModel
     private readonly ApiClient _api;
 
     [BindProperty]
-    public ApiClient.AccountCreateDto Form { get; set; } = new("", 0m);
+    public AccountFormModel Form { get; set; } = new();
 
     public CreateModel(ApiClient api)
     {
@@ -27,7 +27,8 @@ public class CreateModel : PageModel
             return Page();
         }
 
-        await _api.CreateAccountAsync(Form);
+        var dto = new ApiClient.AccountCreateDto(Form.Name, Form.StartingBalance, Form.Currency);
+        await _api.CreateAccountAsync(dto);
         return RedirectToPage("/Index");
     }
 }

--- a/BudgetSystem.Web/Pages/Accounts/Models/AccountFormModel.cs
+++ b/BudgetSystem.Web/Pages/Accounts/Models/AccountFormModel.cs
@@ -1,0 +1,16 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace BudgetSystem.Web.Pages.Accounts;
+
+public class AccountFormModel
+{
+    [Display(Name = "Name")]
+    public string Name { get; set; } = string.Empty;
+
+    [Display(Name = "Starting Balance")]
+    public decimal StartingBalance { get; set; }
+
+    [Display(Name = "Currency")]
+    public string Currency { get; set; } = string.Empty;
+}
+


### PR DESCRIPTION
## Summary
- add `AccountFormModel` with display annotations for account fields
- update `Create` page model to bind to `AccountFormModel` and map to API DTO before creation

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a58da84d908329b134336ab91628a8