### PR TITLE
Remove duplicate header links and redesign footer

### DIFF
--- a/BudgetSystem.Web/Pages/Shared/_Layout.cshtml
+++ b/BudgetSystem.Web/Pages/Shared/_Layout.cshtml
@@ -60,17 +60,6 @@
                     </li>
                 </ul>
 
-                <ul class="navbar-nav">
-                    <li class="nav-item ms-sm-3">
-                        <a class="nav-link @swaggerDisabled" href="@swaggerHref" target="_blank" rel="noopener">
-                            API Swagger
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link text-dark @Active("/Privacy")" asp-area="" asp-page="/Privacy">Privacy</a>
-                    </li>
-                </ul>
-
                 <!-- Right: utilities -->
                 <div class="d-flex align-items-center gap-2">
                     <a class="btn btn-outline-primary btn-sm @swaggerDisabled"
@@ -91,9 +80,11 @@
     </main>
 </div>
 
-<footer class="border-top footer text-muted">
-    <div class="container">
-        &copy; @DateTime.UtcNow.Year - BudgetSystem.Web - <a asp-area="" asp-page="/Privacy">Privacy</a>
+<footer class="mt-auto border-top py-3">
+    <div class="container text-center text-muted">
+        &copy; @DateTime.UtcNow.Year - BudgetSystem.Web
+        <span class="mx-2">&middot;</span>
+        <a class="text-decoration-none" asp-area="" asp-page="/Privacy">Privacy</a>
     </div>
 </footer>
 

--- a/BudgetSystem.Web/Pages/Shared/_Layout.cshtml.css
+++ b/BudgetSystem.Web/Pages/Shared/_Layout.cshtml.css
@@ -39,13 +39,6 @@ button.accept-policy {
   line-height: inherit;
 }
 
-.footer {
-  position: absolute;
-  bottom: 0;
-  width: 100%;
-  white-space: nowrap;
-  line-height: 60px;
-}
 
 .card { border-radius: 0.75rem; }
 .card .form-label { font-weight: 600; }


### PR DESCRIPTION
## Summary
- eliminate duplicate API Swagger and Privacy links in the navbar
- center and restyle the footer for a cleaner look

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a59af6e3e883298914e1ceb57ffc9d