### PR TITLE
Display friendly names in index tables

### DIFF
--- a/BudgetSystem.Web/Pages/Budgets/Index.cshtml
+++ b/BudgetSystem.Web/Pages/Budgets/Index.cshtml
@@ -24,8 +24,8 @@
             <td>@b.Year</td>
             <td>@b.Month</td>
             <td>@b.LimitAmount</td>
-            <td>@b.AccountId</td>
-            <td>@b.CategoryId</td>
+            <td>@b.AccountName</td>
+            <td>@b.CategoryName</td>
             <td>@b.CreatedUtc.ToLocalTime()</td>
         </tr>
     }

--- a/BudgetSystem.Web/Pages/Budgets/Index.cshtml.cs
+++ b/BudgetSystem.Web/Pages/Budgets/Index.cshtml.cs
@@ -1,15 +1,32 @@
 using BudgetSystem.Client;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using System.Linq;
 
 namespace BudgetSystem.Web.Pages.Budgets;
 
 public class IndexModel(ApiClient api) : PageModel
 {
-    public List<ApiClient.BudgetVm> Budgets { get; private set; } = new();
+    public record BudgetViewModel(int Id, int Year, int Month, decimal LimitAmount, string AccountName, string? CategoryName, DateTime CreatedUtc);
+
+    public List<BudgetViewModel> Budgets { get; private set; } = new();
 
     public async Task OnGet()
     {
-        Budgets = await api.GetBudgetsAsync();
+        var budgets = await api.GetBudgetsAsync();
+        var accounts = await api.GetAccountsAsync();
+        var accountLookup = accounts.ToDictionary(a => a.Id, a => a.Name);
+        var categories = await api.GetCategoriesAsync();
+        var categoryLookup = categories.ToDictionary(c => c.Id, c => c.Name);
+
+        Budgets = budgets.Select(b =>
+            new BudgetViewModel(
+                b.Id,
+                b.Year,
+                b.Month,
+                b.LimitAmount,
+                accountLookup.TryGetValue(b.AccountId, out var accName) ? accName : string.Empty,
+                b.CategoryId.HasValue && categoryLookup.TryGetValue(b.CategoryId.Value, out var catName) ? catName : null,
+                b.CreatedUtc)).ToList();
     }
 }
 

--- a/BudgetSystem.Web/Pages/Categories/Index.cshtml
+++ b/BudgetSystem.Web/Pages/Categories/Index.cshtml
@@ -22,7 +22,7 @@
             <td>@c.Id</td>
             <td>@c.Name</td>
             <td>@c.Type</td>
-            <td>@c.AccountId</td>
+            <td>@c.AccountName</td>
             <td>@c.CreatedUtc.ToLocalTime()</td>
         </tr>
     }

--- a/BudgetSystem.Web/Pages/Categories/Index.cshtml.cs
+++ b/BudgetSystem.Web/Pages/Categories/Index.cshtml.cs
@@ -1,14 +1,27 @@
 using BudgetSystem.Client;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using System.Linq;
 
 namespace BudgetSystem.Web.Pages.Categories;
 
 public class IndexModel(ApiClient api) : PageModel
 {
-    public List<ApiClient.CategoryVm> Categories { get; private set; } = new();
+    public record CategoryViewModel(int Id, string Name, ApiClient.TransactionType Type, string? AccountName, DateTime CreatedUtc);
+
+    public List<CategoryViewModel> Categories { get; private set; } = new();
 
     public async Task OnGet()
     {
-        Categories = await api.GetCategoriesAsync();
+        var categories = await api.GetCategoriesAsync();
+        var accounts = await api.GetAccountsAsync();
+        var accountLookup = accounts.ToDictionary(a => a.Id, a => a.Name);
+
+        Categories = categories.Select(c =>
+            new CategoryViewModel(
+                c.Id,
+                c.Name,
+                c.Type,
+                c.AccountId.HasValue && accountLookup.TryGetValue(c.AccountId.Value, out var name) ? name : null,
+                c.CreatedUtc)).ToList();
     }
 }

--- a/BudgetSystem.Web/Pages/Transactions/Index.cshtml
+++ b/BudgetSystem.Web/Pages/Transactions/Index.cshtml
@@ -16,6 +16,8 @@
             <th>Date</th>
             <th>Amount</th>
             <th>Type</th>
+            <th>Account</th>
+            <th>Category</th>
         </tr>
     </thead>
     <tbody>
@@ -26,6 +28,8 @@
             <td>@t.Date.ToLocalTime()</td>
             <td>@t.Amount</td>
             <td>@t.Type</td>
+            <td>@t.AccountName</td>
+            <td>@t.CategoryName</td>
         </tr>
     }
     </tbody>

--- a/BudgetSystem.Web/Pages/Transactions/Index.cshtml.cs
+++ b/BudgetSystem.Web/Pages/Transactions/Index.cshtml.cs
@@ -1,14 +1,30 @@
 using BudgetSystem.Client;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using System.Linq;
 
 namespace BudgetSystem.Web.Pages.Transactions;
 
 public class IndexModel(ApiClient api) : PageModel
 {
-    public List<ApiClient.TransactionVm> Transactions { get; private set; } = new();
+    public record TransactionViewModel(int Id, DateTime Date, decimal Amount, ApiClient.TransactionType Type, string AccountName, string? CategoryName);
+
+    public List<TransactionViewModel> Transactions { get; private set; } = new();
 
     public async Task OnGet()
     {
-        Transactions = await api.GetTransactionsAsync();
+        var transactions = await api.GetTransactionsAsync();
+        var accounts = await api.GetAccountsAsync();
+        var accountLookup = accounts.ToDictionary(a => a.Id, a => a.Name);
+        var categories = await api.GetCategoriesAsync();
+        var categoryLookup = categories.ToDictionary(c => c.Id, c => c.Name);
+
+        Transactions = transactions.Select(t =>
+            new TransactionViewModel(
+                t.Id,
+                t.Date,
+                t.Amount,
+                t.Type,
+                accountLookup.TryGetValue(t.AccountId, out var accName) ? accName : string.Empty,
+                t.CategoryId.HasValue && categoryLookup.TryGetValue(t.CategoryId.Value, out var catName) ? catName : null)).ToList();
     }
 }


### PR DESCRIPTION
## Summary
- Show account names in Categories list
- Replace account and category IDs with names in Budgets table
- Include account and category labels in Transactions table

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed, 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a59ddbf95c8329b3d857a6c14a48a9