### PR TITLE
style: apply account page design to forms

### DIFF
--- a/BudgetSystem.Web/Pages/Budgets/Create.cshtml
+++ b/BudgetSystem.Web/Pages/Budgets/Create.cshtml
@@ -4,38 +4,59 @@
     ViewData["Title"] = "Create Budget";
 }
 
-<h1>Create Budget</h1>
+<div class="container py-4">
+  <div class="row justify-content-center">
+    <div class="col-12 col-md-8 col-lg-6">
+      <div class="card shadow-sm border-0">
+        <div class="card-header bg-primary text-white">
+          <h1 class="h5 mb-0">Create Budget</h1>
+        </div>
 
-<form method="post">
-    <div class="mb-3">
-        <label asp-for="Form.Year" class="form-label"></label>
-        <input asp-for="Form.Year" class="form-control" />
-        <span asp-validation-for="Form.Year" class="text-danger"></span>
+        <div class="card-body">
+          <div asp-validation-summary="ModelOnly" class="alert alert-danger" role="alert"></div>
+
+          <form method="post" novalidate>
+            <div class="mb-3">
+              <label asp-for="Form.Year" class="form-label"></label>
+              <input asp-for="Form.Year" class="form-control" />
+              <span asp-validation-for="Form.Year" class="text-danger small"></span>
+            </div>
+            <div class="mb-3">
+              <label asp-for="Form.Month" class="form-label"></label>
+              <input asp-for="Form.Month" class="form-control" />
+              <span asp-validation-for="Form.Month" class="text-danger small"></span>
+            </div>
+            <div class="mb-3">
+              <label asp-for="Form.LimitAmount" class="form-label"></label>
+              <input asp-for="Form.LimitAmount" class="form-control" />
+              <span asp-validation-for="Form.LimitAmount" class="text-danger small"></span>
+            </div>
+            <div class="mb-3">
+              <label asp-for="Form.AccountId" class="form-label"></label>
+              <select asp-for="Form.AccountId" class="form-select" asp-items="Model.Accounts"></select>
+              <span asp-validation-for="Form.AccountId" class="text-danger small"></span>
+            </div>
+            <div class="mb-3">
+              <label asp-for="Form.CategoryId" class="form-label"></label>
+              <select asp-for="Form.CategoryId" class="form-select" asp-items="Model.Categories">
+                <option value="">-- None --</option>
+              </select>
+              <span asp-validation-for="Form.CategoryId" class="text-danger small"></span>
+            </div>
+            <div class="d-flex gap-2">
+              <a asp-page="./Index" class="btn btn-outline-secondary">Cancel</a>
+              <button type="submit" class="btn btn-primary">Create</button>
+            </div>
+          </form>
+        </div>
+
+        <div class="card-footer text-muted small">
+          Fields marked with errors must be fixed before submitting.
+        </div>
+      </div>
     </div>
-    <div class="mb-3">
-        <label asp-for="Form.Month" class="form-label"></label>
-        <input asp-for="Form.Month" class="form-control" />
-        <span asp-validation-for="Form.Month" class="text-danger"></span>
-    </div>
-    <div class="mb-3">
-        <label asp-for="Form.LimitAmount" class="form-label"></label>
-        <input asp-for="Form.LimitAmount" class="form-control" />
-        <span asp-validation-for="Form.LimitAmount" class="text-danger"></span>
-    </div>
-    <div class="mb-3">
-        <label asp-for="Form.AccountId" class="form-label"></label>
-        <select asp-for="Form.AccountId" class="form-select" asp-items="Model.Accounts"></select>
-        <span asp-validation-for="Form.AccountId" class="text-danger"></span>
-    </div>
-    <div class="mb-3">
-        <label asp-for="Form.CategoryId" class="form-label"></label>
-        <select asp-for="Form.CategoryId" class="form-select" asp-items="Model.Categories">
-            <option value="">-- None --</option>
-        </select>
-        <span asp-validation-for="Form.CategoryId" class="text-danger"></span>
-    </div>
-    <button type="submit" class="btn btn-primary">Create</button>
-</form>
+  </div>
+</div>
 
 @section Scripts {
     <partial name="_ValidationScriptsPartial" />

--- a/BudgetSystem.Web/Pages/Categories/Create.cshtml
+++ b/BudgetSystem.Web/Pages/Categories/Create.cshtml
@@ -5,26 +5,47 @@
     ViewData["Title"] = "Create Category";
 }
 
-<h1>Create Category</h1>
+<div class="container py-4">
+  <div class="row justify-content-center">
+    <div class="col-12 col-md-8 col-lg-6">
+      <div class="card shadow-sm border-0">
+        <div class="card-header bg-primary text-white">
+          <h1 class="h5 mb-0">Create Category</h1>
+        </div>
 
-<form method="post">
-    <div class="mb-3">
-        <label asp-for="Form.Name" class="form-label"></label>
-        <input asp-for="Form.Name" class="form-control" />
-        <span asp-validation-for="Form.Name" class="text-danger"></span>
+        <div class="card-body">
+          <div asp-validation-summary="ModelOnly" class="alert alert-danger" role="alert"></div>
+
+          <form method="post" novalidate>
+            <div class="mb-3">
+              <label asp-for="Form.Name" class="form-label"></label>
+              <input asp-for="Form.Name" class="form-control" />
+              <span asp-validation-for="Form.Name" class="text-danger small"></span>
+            </div>
+            <div class="mb-3">
+              <label asp-for="Form.Type" class="form-label"></label>
+              <select asp-for="Form.Type" class="form-select" asp-items="Html.GetEnumSelectList<ApiClient.TransactionType>()"></select>
+              <span asp-validation-for="Form.Type" class="text-danger small"></span>
+            </div>
+            <div class="mb-3">
+              <label asp-for="Form.AccountId" class="form-label"></label>
+              <input asp-for="Form.AccountId" class="form-control" />
+              <span asp-validation-for="Form.AccountId" class="text-danger small"></span>
+            </div>
+            <div class="d-flex gap-2">
+              <a asp-page="./Index" class="btn btn-outline-secondary">Cancel</a>
+              <button type="submit" class="btn btn-primary">Create</button>
+            </div>
+          </form>
+        </div>
+
+        <div class="card-footer text-muted small">
+          Fields marked with errors must be fixed before submitting.
+        </div>
+      </div>
     </div>
-    <div class="mb-3">
-        <label asp-for="Form.Type" class="form-label"></label>
-        <select asp-for="Form.Type" class="form-select" asp-items="Html.GetEnumSelectList<ApiClient.TransactionType>()"></select>
-        <span asp-validation-for="Form.Type" class="text-danger"></span>
-    </div>
-    <div class="mb-3">
-        <label asp-for="Form.AccountId" class="form-label"></label>
-        <input asp-for="Form.AccountId" class="form-control" />
-        <span asp-validation-for="Form.AccountId" class="text-danger"></span>
-    </div>
-    <button type="submit" class="btn btn-primary">Create</button>
-</form>
+  </div>
+</div>
 
 @section Scripts {
     <partial name="_ValidationScriptsPartial" />

--- a/BudgetSystem.Web/Pages/Transactions/Create.cshtml
+++ b/BudgetSystem.Web/Pages/Transactions/Create.cshtml
@@ -5,52 +5,73 @@
     ViewData["Title"] = "Create Transaction";
 }
 
-<h1>Create Transaction</h1>
+<div class="container py-4">
+  <div class="row justify-content-center">
+    <div class="col-12 col-md-8 col-lg-6">
+      <div class="card shadow-sm border-0">
+        <div class="card-header bg-primary text-white">
+          <h1 class="h5 mb-0">Create Transaction</h1>
+        </div>
 
-<form method="post">
-    <div class="mb-3">
-        <label asp-for="Form.Date" class="form-label"></label>
-        <input asp-for="Form.Date" class="form-control" />
-        <span asp-validation-for="Form.Date" class="text-danger"></span>
+        <div class="card-body">
+          <div asp-validation-summary="ModelOnly" class="alert alert-danger" role="alert"></div>
+
+          <form method="post" novalidate>
+            <div class="mb-3">
+              <label asp-for="Form.Date" class="form-label"></label>
+              <input asp-for="Form.Date" class="form-control" />
+              <span asp-validation-for="Form.Date" class="text-danger small"></span>
+            </div>
+            <div class="mb-3">
+              <label asp-for="Form.Amount" class="form-label"></label>
+              <input asp-for="Form.Amount" class="form-control" />
+              <span asp-validation-for="Form.Amount" class="text-danger small"></span>
+            </div>
+            <div class="mb-3">
+              <label asp-for="Form.Type" class="form-label"></label>
+              <select asp-for="Form.Type" class="form-select" asp-items="Html.GetEnumSelectList<ApiClient.TransactionType>()"></select>
+              <span asp-validation-for="Form.Type" class="text-danger small"></span>
+            </div>
+            <div class="mb-3">
+              <label asp-for="Form.AccountId" class="form-label"></label>
+              <select asp-for="Form.AccountId" class="form-select" asp-items="Model.AccountOptions"></select>
+              <span asp-validation-for="Form.AccountId" class="text-danger small"></span>
+            </div>
+            <div class="mb-3">
+              <label asp-for="Form.CategoryId" class="form-label"></label>
+              <select asp-for="Form.CategoryId" class="form-select" asp-items="Model.CategoryOptions">
+                <option value="">-- None --</option>
+              </select>
+              <span asp-validation-for="Form.CategoryId" class="text-danger small"></span>
+            </div>
+            <div class="mb-3">
+              <label asp-for="Form.FromAccountId" class="form-label"></label>
+              <select asp-for="Form.FromAccountId" class="form-select" asp-items="Model.AccountOptions">
+                <option value="">-- None --</option>
+              </select>
+              <span asp-validation-for="Form.FromAccountId" class="text-danger small"></span>
+            </div>
+            <div class="mb-3">
+              <label asp-for="Form.ToAccountId" class="form-label"></label>
+              <select asp-for="Form.ToAccountId" class="form-select" asp-items="Model.AccountOptions">
+                <option value="">-- None --</option>
+              </select>
+              <span asp-validation-for="Form.ToAccountId" class="text-danger small"></span>
+            </div>
+            <div class="d-flex gap-2">
+              <a asp-page="./Index" class="btn btn-outline-secondary">Cancel</a>
+              <button type="submit" class="btn btn-primary">Create</button>
+            </div>
+          </form>
+        </div>
+
+        <div class="card-footer text-muted small">
+          Fields marked with errors must be fixed before submitting.
+        </div>
+      </div>
     </div>
-    <div class="mb-3">
-        <label asp-for="Form.Amount" class="form-label"></label>
-        <input asp-for="Form.Amount" class="form-control" />
-        <span asp-validation-for="Form.Amount" class="text-danger"></span>
-    </div>
-    <div class="mb-3">
-        <label asp-for="Form.Type" class="form-label"></label>
-        <select asp-for="Form.Type" class="form-select" asp-items="Html.GetEnumSelectList<ApiClient.TransactionType>()"></select>
-        <span asp-validation-for="Form.Type" class="text-danger"></span>
-    </div>
-    <div class="mb-3">
-        <label asp-for="Form.AccountId" class="form-label"></label>
-        <select asp-for="Form.AccountId" class="form-select" asp-items="Model.AccountOptions"></select>
-        <span asp-validation-for="Form.AccountId" class="text-danger"></span>
-    </div>
-    <div class="mb-3">
-        <label asp-for="Form.CategoryId" class="form-label"></label>
-        <select asp-for="Form.CategoryId" class="form-select" asp-items="Model.CategoryOptions">
-            <option value="">-- None --</option>
-        </select>
-        <span asp-validation-for="Form.CategoryId" class="text-danger"></span>
-    </div>
-    <div class="mb-3">
-        <label asp-for="Form.FromAccountId" class="form-label"></label>
-        <select asp-for="Form.FromAccountId" class="form-select" asp-items="Model.AccountOptions">
-            <option value="">-- None --</option>
-        </select>
-        <span asp-validation-for="Form.FromAccountId" class="text-danger"></span>
-    </div>
-    <div class="mb-3">
-        <label asp-for="Form.ToAccountId" class="form-label"></label>
-        <select asp-for="Form.ToAccountId" class="form-select" asp-items="Model.AccountOptions">
-            <option value="">-- None --</option>
-        </select>
-        <span asp-validation-for="Form.ToAccountId" class="text-danger"></span>
-    </div>
-    <button type="submit" class="btn btn-primary">Create</button>
-</form>
+  </div>
+</div>
 
 @section Scripts {
     <partial name="_ValidationScriptsPartial" />


### PR DESCRIPTION
## Summary
- Align budget, category, and transaction creation pages with the account page design
- Add card layout, validation summary, and cancel buttons for consistent forms

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a5a19a656c8329b8f65c2c2b5b72e4