### PR TITLE
Fix category index view compilation errors

### DIFF
--- a/BudgetSystem.Web/Pages/Categories/Index.cshtml
+++ b/BudgetSystem.Web/Pages/Categories/Index.cshtml
@@ -13,13 +13,11 @@
 
     @if (Model.Categories is null || !Model.Categories.Any())
     {
-        <tr>
-            <td>@c.Id</td>
-            <td>@c.Name</td>
-            <td>@c.Type</td>
-            <td>@c.AccountName</td>
-            <td>@c.CreatedUtc.ToLocalTime()</td>
-        </tr>
+        <div class="card-body text-center text-muted py-5">
+            <p class="mb-1 fw-semibold">No categories yet</p>
+            <p class="mb-3">Create your first category to get started.</p>
+            <a class="btn btn-outline-primary btn-sm" asp-page="Create">Create Category</a>
+        </div>
     }
     else
     {
@@ -37,7 +35,7 @@
             <tbody>
             @foreach (var c in Model.Categories)
             {
-                var type = c.Type?.ToString() ?? "";
+                var type = c.Type.ToString();
                 var badgeClass = type.Equals("Expense", StringComparison.OrdinalIgnoreCase) ? "text-bg-danger"
                                : type.Equals("Income", StringComparison.OrdinalIgnoreCase)  ? "text-bg-success"
                                : "text-bg-secondary";
@@ -54,9 +52,13 @@
                         {
                             <span class="badge text-bg-light border">@c.AccountName</span>
                         }
-                        else
+                        else if (c.AccountId.HasValue)
                         {
                             <span class="badge text-bg-light border">#@c.AccountId</span>
+                        }
+                        else
+                        {
+                            <span class="badge text-bg-light border">&mdash;</span>
                         }
                     </td>
                     <td class="text-nowrap">

--- a/BudgetSystem.Web/Pages/Categories/Index.cshtml.cs
+++ b/BudgetSystem.Web/Pages/Categories/Index.cshtml.cs
@@ -6,7 +6,7 @@ namespace BudgetSystem.Web.Pages.Categories;
 
 public class IndexModel(ApiClient api) : PageModel
 {
-    public record CategoryViewModel(int Id, string Name, ApiClient.TransactionType Type, string? AccountName, DateTime CreatedUtc);
+    public record CategoryViewModel(int Id, string Name, ApiClient.TransactionType Type, int? AccountId, string? AccountName, DateTime CreatedUtc);
 
     public List<CategoryViewModel> Categories { get; private set; } = new();
 
@@ -21,6 +21,7 @@ public class IndexModel(ApiClient api) : PageModel
                 c.Id,
                 c.Name,
                 c.Type,
+                c.AccountId,
                 c.AccountId.HasValue && accountLookup.TryGetValue(c.AccountId.Value, out var name) ? name : null,
                 c.CreatedUtc)).ToList();
     }


### PR DESCRIPTION
## Summary
- Display helpful message when no categories exist
- Replace nullable enum usage with direct string conversion
- Extend category view model with account ID for fallback display

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a5a2e7ebc88329a9e704b3343967e9