### PR TITLE
Style budgets and transactions pages

### DIFF
--- a/BudgetSystem.Web/Pages/Budgets/Create.cshtml
+++ b/BudgetSystem.Web/Pages/Budgets/Create.cshtml
@@ -28,7 +28,13 @@
             </div>
             <div class="mb-3">
               <label asp-for="Form.LimitAmount" class="form-label"></label>
-              <input asp-for="Form.LimitAmount" class="form-control" />
+              <div class="input-group">
+                <span class="input-group-text" id="curPrefix">₱</span>
+                <input asp-for="Form.LimitAmount"
+                       class="form-control"
+                       type="number" step="0.01" min="0" aria-describedby="curPrefix"
+                       placeholder="0.00" />
+              </div>
               <span asp-validation-for="Form.LimitAmount" class="text-danger small"></span>
             </div>
             <div class="mb-3">

--- a/BudgetSystem.Web/Pages/Budgets/Index.cshtml
+++ b/BudgetSystem.Web/Pages/Budgets/Index.cshtml
@@ -4,31 +4,60 @@
     ViewData["Title"] = "Budgets";
 }
 
-<h1 class="mt-3">Budgets</h1>
+<div class="container py-3">
+  <div class="card shadow-sm border-0">
+    <div class="card-header d-flex justify-content-between align-items-center bg-white">
+      <h1 class="h5 mb-0">Budgets</h1>
+      <a class="btn btn-primary btn-sm" asp-page="Create">Create Budget</a>
+    </div>
 
-<p>
-    <a class="btn btn-primary" asp-page="Create">Create Budget</a>
-    </p>
-
-<table class="table table-striped">
-    <thead>
-        <tr>
-            <th>Id</th><th>Year</th><th>Month</th><th>Limit</th><th>Account</th><th>Category</th><th>Created</th>
-        </tr>
-    </thead>
-    <tbody>
-    @foreach (var b in Model.Budgets)
+    @if (Model.Budgets is null || !Model.Budgets.Any())
     {
-        <tr>
-            <td>@b.Id</td>
-            <td>@b.Year</td>
-            <td>@b.Month</td>
-            <td>@b.LimitAmount</td>
-            <td>@b.AccountName</td>
-            <td>@b.CategoryName</td>
-            <td>@b.CreatedUtc.ToLocalTime()</td>
-        </tr>
+        <div class="card-body text-center text-muted py-5">
+            <p class="mb-1 fw-semibold">No budgets yet</p>
+            <p class="mb-3">Create your first budget to get started.</p>
+            <a class="btn btn-outline-primary btn-sm" asp-page="Create">Create Budget</a>
+        </div>
     }
-    </tbody>
-</table>
+    else
+    {
+        <div class="table-responsive">
+          <table class="table table-hover table-sm align-middle mb-0">
+            <thead class="table-light sticky-head">
+              <tr>
+                <th style="width: 80px;">ID</th>
+                <th style="width: 100px;">Year</th>
+                <th style="width: 100px;">Month</th>
+                <th class="text-end" style="width: 160px;">Limit</th>
+                <th>Account</th>
+                <th>Category</th>
+                <th style="width: 210px;">Created</th>
+              </tr>
+            </thead>
+            <tbody>
+            @foreach (var b in Model.Budgets)
+            {
+                <tr>
+                    <td class="text-muted">@b.Id</td>
+                    <td>@b.Year</td>
+                    <td>@b.Month</td>
+                    <td class="text-end font-monospace">@($"{b.LimitAmount:N2}")</td>
+                    <td class="fw-semibold">@b.AccountName</td>
+                    <td>@b.CategoryName</td>
+                    <td>
+                        @{
+                            var local = b.CreatedUtc.ToLocalTime();
+                        }
+                        <time title="@local.ToString(\"yyyy-MM-dd HH:mm:ss\")" class="text-nowrap">
+                            @local.ToString("MMM d, yyyy · h:mm tt")
+                        </time>
+                    </td>
+                </tr>
+            }
+            </tbody>
+          </table>
+        </div>
+    }
+  </div>
+</div>
 

--- a/BudgetSystem.Web/Pages/Transactions/Create.cshtml
+++ b/BudgetSystem.Web/Pages/Transactions/Create.cshtml
@@ -19,12 +19,18 @@
           <form method="post" novalidate>
             <div class="mb-3">
               <label asp-for="Form.Date" class="form-label"></label>
-              <input asp-for="Form.Date" class="form-control" />
+              <input asp-for="Form.Date" class="form-control" type="datetime-local" />
               <span asp-validation-for="Form.Date" class="text-danger small"></span>
             </div>
             <div class="mb-3">
               <label asp-for="Form.Amount" class="form-label"></label>
-              <input asp-for="Form.Amount" class="form-control" />
+              <div class="input-group">
+                <span class="input-group-text" id="curPrefix">₱</span>
+                <input asp-for="Form.Amount"
+                       class="form-control"
+                       type="number" step="0.01" min="0" aria-describedby="curPrefix"
+                       placeholder="0.00" />
+              </div>
               <span asp-validation-for="Form.Amount" class="text-danger small"></span>
             </div>
             <div class="mb-3">

--- a/BudgetSystem.Web/Pages/Transactions/Index.cshtml
+++ b/BudgetSystem.Web/Pages/Transactions/Index.cshtml
@@ -3,34 +3,57 @@
 @{
     ViewData["Title"] = "Transactions";
 }
-<h1 class="mt-3">Transactions</h1>
+<div class="container py-3">
+  <div class="card shadow-sm border-0">
+    <div class="card-header d-flex justify-content-between align-items-center bg-white">
+      <h1 class="h5 mb-0">Transactions</h1>
+      <a class="btn btn-primary btn-sm" asp-page="Create">Create Transaction</a>
+    </div>
 
-<p>
-    <a class="btn btn-primary" asp-page="Create">Create Transaction</a>
-</p>
-
-<table class="table table-striped">
-    <thead>
-        <tr>
-            <th>Id</th>
-            <th>Date</th>
-            <th>Amount</th>
-            <th>Type</th>
-            <th>Account</th>
-            <th>Category</th>
-        </tr>
-    </thead>
-    <tbody>
-    @foreach (var t in Model.Transactions)
+    @if (Model.Transactions is null || !Model.Transactions.Any())
     {
-        <tr>
-            <td>@t.Id</td>
-            <td>@t.Date.ToLocalTime()</td>
-            <td>@t.Amount</td>
-            <td>@t.Type</td>
-            <td>@t.AccountName</td>
-            <td>@t.CategoryName</td>
-        </tr>
+        <div class="card-body text-center text-muted py-5">
+            <p class="mb-1 fw-semibold">No transactions yet</p>
+            <p class="mb-3">Record your first transaction to get started.</p>
+            <a class="btn btn-outline-primary btn-sm" asp-page="Create">Create Transaction</a>
+        </div>
     }
-    </tbody>
-</table>
+    else
+    {
+        <div class="table-responsive">
+          <table class="table table-hover table-sm align-middle mb-0">
+            <thead class="table-light sticky-head">
+              <tr>
+                <th style="width: 80px;">ID</th>
+                <th>Date</th>
+                <th class="text-end" style="width: 160px;">Amount</th>
+                <th style="width: 120px;">Type</th>
+                <th>Account</th>
+                <th>Category</th>
+              </tr>
+            </thead>
+            <tbody>
+            @foreach (var t in Model.Transactions)
+            {
+                <tr>
+                    <td class="text-muted">@t.Id</td>
+                    <td>
+                        @{
+                            var local = t.Date.ToLocalTime();
+                        }
+                        <time title="@local.ToString(\"yyyy-MM-dd HH:mm:ss\")" class="text-nowrap">
+                            @local.ToString("MMM d, yyyy · h:mm tt")
+                        </time>
+                    </td>
+                    <td class="text-end font-monospace">@($"{t.Amount:N2}")</td>
+                    <td><span class="badge text-bg-secondary">@t.Type</span></td>
+                    <td class="fw-semibold">@t.AccountName</td>
+                    <td>@t.CategoryName</td>
+                </tr>
+            }
+            </tbody>
+          </table>
+        </div>
+    }
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- Apply card-based table layout with empty-state messaging for budgets list
- Align budgets and transactions forms with currency input groups
- Upgrade transactions list to match table design used elsewhere

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a5a706e8b48329adcd11a0f6f8d8ab