### PR TITLE
Fix Razor title attribute quoting

### DIFF
--- a/BudgetSystem.Web/Pages/Budgets/Index.cshtml
+++ b/BudgetSystem.Web/Pages/Budgets/Index.cshtml
@@ -48,7 +48,7 @@
                         @{
                             var local = b.CreatedUtc.ToLocalTime();
                         }
-                        <time title="@local.ToString(\"yyyy-MM-dd HH:mm:ss\")" class="text-nowrap">
+                        <time title='@local.ToString("yyyy-MM-dd HH:mm:ss")' class="text-nowrap">
                             @local.ToString("MMM d, yyyy · h:mm tt")
                         </time>
                     </td>

--- a/BudgetSystem.Web/Pages/Transactions/Index.cshtml
+++ b/BudgetSystem.Web/Pages/Transactions/Index.cshtml
@@ -41,7 +41,7 @@
                         @{
                             var local = t.Date.ToLocalTime();
                         }
-                        <time title="@local.ToString(\"yyyy-MM-dd HH:mm:ss\")" class="text-nowrap">
+                        <time title='@local.ToString("yyyy-MM-dd HH:mm:ss")' class="text-nowrap">
                             @local.ToString("MMM d, yyyy · h:mm tt")
                         </time>
                     </td>


### PR DESCRIPTION
## Summary
- avoid Razor parser confusion by using single quotes around time titles in budgets and transactions views

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5ab6bfacc832989e8cabd89159b61